### PR TITLE
Second part of libffi related work

### DIFF
--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -56,7 +56,7 @@ jobs:
           run: |
             set -x
             uname -a
-            apt update && apt-get install -y ca-certificates pkg-config make gcc g++ check # todo: libffi-dev
+            apt update && apt-get install -y ca-certificates pkg-config make gcc g++ check libffi-dev
 
             tar -C /usr/local -xzf go.tar.gz && rm go.tar.gz
             export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/buildAndTest.yaml
+++ b/.github/workflows/buildAndTest.yaml
@@ -50,7 +50,7 @@ jobs:
 
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
-          githubToken: ${{ github.token }}
+          # githubToken: ${{ github.token }}
 
           # Set an output parameter `uname` for use in subsequent steps
           run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
             "name": "(lldb) Launch - Macos",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${fileDirname}/value_with_args_test",
+            "program": "${fileDirname}/value_ffi_test",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/examples/c_ffi_call/main.c
+++ b/examples/c_ffi_call/main.c
@@ -26,7 +26,7 @@ int main() {
             free(s);
         }
 
-        metac_value_t *p_res_val = metac_new_value_with_call_result(p_params_val);
+        metac_value_t *p_res_val = metac_new_value_with_call_result(metac_value_entry(p_params_val));
         if (metac_value_call(p_params_val, (void (*)(void))test_function1_with_args, p_res_val) == 0) {
             char * ret = NULL;
             if (p_res_val != NULL) {

--- a/examples/c_ffi_call/main.c
+++ b/examples/c_ffi_call/main.c
@@ -27,7 +27,7 @@ int main() {
         }
 
         metac_value_t *p_res_val = metac_new_value_with_call_result(metac_value_entry(p_params_val));
-        if (metac_value_call(p_params_val, (void (*)(void))test_function1_with_args, p_res_val) == 0) {
+        if (metac_value_ffi_call(p_params_val, (void (*)(void))test_function1_with_args, p_res_val) == 0) {
             char * ret = NULL;
             if (p_res_val != NULL) {
                 ret = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -341,9 +341,6 @@ static int _val_to_ffi_type(metac_entry_t * p_entry, metac_flag_t variadic, ffi_
 
 static int _call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value,
     struct _va_list_entry * p_val_list_entries, metac_num_t va_list_number) {
-    // to support va_list
-    struct va_list_container va_list_c;
-    void * _ptr_ = NULL;
 
     _check_(
         p_param_storage_val == NULL ||
@@ -684,7 +681,7 @@ static int _call_wrapper(metac_value_t * p_param_storage_val, void (*fn)(void), 
 // if we see 0 va_list - call directly.
 // if we see 1+ va_lists - call special ffi wrapper and 
 //    put va_list-internals as ... arg. Wrapper will convert ... to va_list and we can feed it to call
-int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value) {
+int metac_value_ffi_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value) {
     _check_(
         p_param_storage_val == NULL ||
         metac_value_has_parameter_load(p_param_storage_val) == 0 ||

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -107,20 +107,22 @@ static int _val_to_ffi_type(metac_entry_t * p_entry, metac_flag_t variadic, ffi_
             return -ENOMEM;
         }
 #if __linux__
-        p_ffi_type->alignment = 0;
+        va_list x;
         p_ffi_type->type = FFI_TYPE_STRUCT;
-        p_ffi_type->size = sizeof(va_list);
-        p_ffi_type->elements = calloc(sizeof(ffi_type)/sizeof(void*) + 1 /* for NULL */, sizeof(ffi_type *));
+        p_ffi_type->size = 8;
+        p_ffi_type->alignment = p_ffi_type->size;
+        p_ffi_type->elements = calloc(p_ffi_type->size/sizeof(void*) + 1 /* for NULL */, sizeof(ffi_type *));
         if (p_ffi_type->elements == NULL) {
             free(p_ffi_type);
             return -(ENOMEM);
         }
-        for (int i = 0; i < sizeof(ffi_type)/sizeof(void*); ++i) {
+        for (int i = 0; i < p_ffi_type->size/sizeof(void*); ++i) {
             p_ffi_type->elements[i] = calloc(1, sizeof(ffi_type));
             if (p_ffi_type->elements[i] != NULL) {
                 memcpy(p_ffi_type->elements[i], &ffi_type_pointer, sizeof(ffi_type));
             }
         }
+        //memcpy(p_ffi_type, &ffi_type_pointer, sizeof(ffi_type));
 #else
         memcpy(p_ffi_type, &ffi_type_pointer, sizeof(ffi_type));
 #endif
@@ -462,11 +464,14 @@ int _call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t *
             assert(va_list_number_cur < va_list_number);
             assert(p_val_list_entries[va_list_number_cur].id == i);
 #if __linux__
-            values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
-            // va_list cp;
-            // va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
-            // vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
-            // va_end(cp);
+            void **p1 = &p_val_list_entries[va_list_number_cur].va_list_c;
+            fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
+            pvalues[i] = &(p_val_list_entries[va_list_number_cur].va_list_c);
+            values[i] = &pvalues[i];
+            va_list cp;
+            va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
+            vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
+            va_end(cp);
             // //va_list cp;
             // va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
             // vfprintf(stderr, "dbg1: %x %x %x %x %x %x\n", cp);

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -464,8 +464,7 @@ int _call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t *
 #if __linux__
             values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
 #else
-            va_list * x = &p_val_list_entries[va_list_number_cur].va_list_c;
-            values[i] = x;
+            values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
 #endif
             ++va_list_number_cur;
             // // simple approach (without recursion)

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -301,61 +301,6 @@ void _cleanup_ffi_type(ffi_type * p_rtype) {
     free(p_rtype);
 }
 
-metac_value_t * metac_new_value_with_call_params(metac_entry_t *p_entry) {
-    metac_value_t * p_val = NULL;
-    metac_parameter_storage_t * p_param_storage = metac_new_parameter_storage();
-    if (p_param_storage != NULL) {
-        p_val = metac_new_value(p_entry, p_param_storage);
-    }
-    return p_val;
-}
-
-void metac_value_with_call_params_delete(metac_value_t * p_param_value) {
-    metac_parameter_storage_t * p_param_storage = (metac_parameter_storage_t *)metac_value_addr(p_param_value);
-    metac_value_delete(p_param_value);
-    metac_parameter_storage_delete(p_param_storage);
-}
-
-metac_value_t * metac_new_value_with_call_result(metac_value_t * p_param_storage_val) {
-    _check_(
-        p_param_storage_val == NULL ||
-        metac_value_has_parameter_load(p_param_storage_val) == 0, NULL);
-
-    metac_value_t * p_res_value = NULL;
-    metac_size_t res_sz = 0;
-
-    metac_entry_t *p_param_storage_entry = metac_value_entry(p_param_storage_val);
-    _check_(p_param_storage_entry == NULL, NULL);
-    _check_(metac_entry_has_parameters(p_param_storage_entry) == 0, NULL);
-
-    if (metac_entry_has_result(p_param_storage_entry) != 0) {
-        metac_entry_t *p_res_entry = metac_entry_result_type(p_param_storage_entry);
-        _check_(p_res_entry == NULL, NULL);
-
-        if (metac_entry_byte_size(p_res_entry, &res_sz) != 0) {
-            return NULL;
-        }
-        _check_(res_sz <= 0, NULL);
-
-        void * p_res_mem = calloc(1, res_sz);
-        p_res_value = metac_new_value(p_res_entry, p_res_mem);
-        if (p_res_value == NULL) {
-            free(p_res_mem);
-            return NULL;
-        }
-    }
-
-    return p_res_value;
-}
-
-void metac_value_with_call_result_delete(metac_value_t * p_res_value) {
-    if (p_res_value == NULL) {
-        return;
-    }
-    free(metac_value_addr(p_res_value));
-    metac_value_delete(p_res_value);
-}
-
 int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value) {
     _check_(
         p_param_storage_val == NULL ||
@@ -475,6 +420,7 @@ int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), meta
     
     _cleanup_ffi_type(rtype);
     if (res_addr == &rc) {
+        assert(metac_entry_has_result(p_param_storage_entry) != 0);
         // we need to pass result back to p_res_value if we used rc as buf (for small data)
         uint8_t * p_res_buf = metac_value_addr(p_res_value);
         for (metac_size_t i = 0;  i < res_sz; ++i) {

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -463,35 +463,18 @@ int _call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t *
             assert(p_val_list_entries[va_list_number_cur].id == i);
 #if __linux__
             values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
+            // va_list cp;
+            // va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
+            // vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
+            // va_end(cp);
+            // //va_list cp;
+            // va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
+            // vfprintf(stderr, "dbg1: %x %x %x %x %x %x\n", cp);
+            // va_end(cp);
 #else
             values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
 #endif
             ++va_list_number_cur;
-            // // simple approach (without recursion)
-            // assert(metac_value_has_parameter_load(p_param_val));
-            // if (_ptr_ != NULL ||    // if we had more than 1 va_list
-            //     metac_value_parameter_count(p_param_val) > 2 /*TODO: set some realistic limit*/) {
-            //     metac_value_delete(p_param_val);
-            //     free(pvalues);
-            //     free(values);
-            //     for (metac_num_t ic = 0; ic <= i; ++ic ) {_cleanup_ffi_type(args[ic]);}
-            //     free(args);
-            //     if (p_last_param_val != NULL) { metac_value_delete(p_last_param_val); }
-            //     return -(EFAULT);
-            // }
-
-            // switch (metac_value_parameter_count(p_param_val)) {
-            //     case 0: {
-            //         VA_LIST_CONTAINER(va_list_c, 0/*extra padding */);
-            //     }break;
-            //     case 1: {
-            //         VA_LIST_CONTAINER(va_list_c, 777);
-            //     }break;
-            //     case 2:{
-            //         VA_LIST_CONTAINER(va_list_c, 777, 888);
-            //     }break;
-            // }
-//            values[i] = &va_list_c;
         }
         metac_value_delete(p_param_val);
     }
@@ -604,6 +587,12 @@ static int _call_wrapper_va(metac_value_t * p_param_storage_val, void (*fn)(void
     va_start(p_val_list_entries[va_list_number_cur].va_list_c.parameters, va_list_number);
     res = _call_wrapper(p_param_storage_val, fn, p_res_value,
             va_list_number_cur + 1, p_val_list_entries, va_list_number);
+// #if __linux__
+//             va_list cp;
+//             va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
+//             vfprintf(stderr, "dbg-after: %x %x %x %x %x %x\n", cp);
+//             va_end(cp);
+// #endif
     va_end(p_val_list_entries[va_list_number_cur].va_list_c.parameters);
     return res;
 }

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -687,7 +687,7 @@ static int _call_wrapper(metac_value_t * p_param_storage_val, void (*fn)(void), 
         free(pvalues);
         free(values);
         // cleanup only variadic. non-variadic were static
-        for (metac_num_t ic = param_count; ic < variadic_param_count; ++ic ) {_cleanup_ffi_type(args[ic]);}
+        for (metac_num_t ic = param_count; ic < param_count + variadic_param_count; ++ic ) {_cleanup_ffi_type(args[ic]);}
         free(args);
 
         return (int)rc;
@@ -771,6 +771,7 @@ int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), meta
                 p_val_list_entries[i].p_val = NULL;
             }
         }
+        free(p_val_list_entries);
     }
     return res;
 }

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -109,7 +109,7 @@ static int _val_to_ffi_type(metac_entry_t * p_entry, metac_flag_t variadic, ffi_
 #if __linux__
         va_list x;
         p_ffi_type->type = FFI_TYPE_STRUCT;
-        p_ffi_type->size = 8;
+        p_ffi_type->size = sizeof(void*);
         p_ffi_type->alignment = p_ffi_type->size;
         p_ffi_type->elements = calloc(p_ffi_type->size/sizeof(void*) + 1 /* for NULL */, sizeof(ffi_type *));
         if (p_ffi_type->elements == NULL) {
@@ -464,14 +464,14 @@ int _call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t *
             assert(va_list_number_cur < va_list_number);
             assert(p_val_list_entries[va_list_number_cur].id == i);
 #if __linux__
-            void **p1 = &p_val_list_entries[va_list_number_cur].va_list_c;
-            fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
+            // void **p1 = &p_val_list_entries[va_list_number_cur].va_list_c;
+            // fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
             pvalues[i] = &(p_val_list_entries[va_list_number_cur].va_list_c);
             values[i] = &pvalues[i];
-            va_list cp;
-            va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
-            vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
-            va_end(cp);
+            // va_list cp;
+            // va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
+            // vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
+            // va_end(cp);
             // //va_list cp;
             // va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
             // vfprintf(stderr, "dbg1: %x %x %x %x %x %x\n", cp);

--- a/examples/c_ffi_call/value_ffi.c
+++ b/examples/c_ffi_call/value_ffi.c
@@ -700,9 +700,8 @@ static int _call_wrapper(metac_value_t * p_param_storage_val, void (*fn)(void), 
 
 // idea: check all params
 // if we see 0 va_list - call directly.
-// if we see 1 va_list - call special wrapper and 
-//    put va_list-internals as ... arg. Wrapper will convert .. to va_list and we can feed it to call
-// if we see more than 1 - we currently don't support this.
+// if we see 1 or more va_list - call special ffi wrapper and 
+//    put va_list-internals as ... arg. Wrapper will convert ... to va_list and we can feed it to call
 int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value) {
     _check_(
         p_param_storage_val == NULL ||

--- a/examples/c_ffi_call/value_ffi.h
+++ b/examples/c_ffi_call/value_ffi.h
@@ -10,5 +10,5 @@
         p_val; \
     })
 
-int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value);
+int metac_value_ffi_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value);
 

--- a/examples/c_ffi_call/value_ffi.h
+++ b/examples/c_ffi_call/value_ffi.h
@@ -1,7 +1,5 @@
 #include "metac/reflect.h"
 
-metac_value_t * metac_new_value_with_call_params(metac_entry_t *p_entry);
-
 #define METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(_tag_map_, _fn_entry_, _fn_, _args_...) ({ \
         metac_value_t * p_val = metac_value_parameter_wrap( \
             metac_new_value_with_call_params(_fn_entry_), _tag_map_, _args_); \
@@ -12,7 +10,5 @@ metac_value_t * metac_new_value_with_call_params(metac_entry_t *p_entry);
         p_val; \
     })
 
-metac_value_t * metac_new_value_with_call_result(metac_value_t * p_param_storage_val);
 int metac_value_call(metac_value_t * p_param_storage_val, void (*fn)(void), metac_value_t * p_res_value);
-void metac_value_with_call_result_delete(metac_value_t * p_res_value);
-void metac_value_with_call_params_delete(metac_value_t * p_param_value);
+

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -11,7 +11,7 @@ static char called[1024];
     called[0] = 0; \
     metac_entry_t * p_entry = METAC_GSYM_LINK_ENTRY(_fn_); \
     metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(_tag_map_, p_entry, _fn_, _args_); \
-    metac_value_t *p_res_val = metac_new_value_with_call_result(p_params_val); \
+    metac_value_t *p_res_val = metac_new_value_with_call_result(p_entry); \
     int res = metac_value_call(p_params_val, (void (*)(void)) _fn_, p_res_val);
 
 #define _CALL_PROCESS_FN_PTR(_tag_map_, _type_, _fn_, _args_...) { \
@@ -19,7 +19,7 @@ static char called[1024];
     WITH_METAC_DECLLOC(dec, _type_ * p = _fn_); \
     metac_entry_t * p_entry = METAC_ENTRY_FROM_DECLLOC(dec, p); \
     metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(_tag_map_, metac_entry_pointer_entry(p_entry), _fn_, _args_); \
-    metac_value_t *p_res_val = metac_new_value_with_call_result(p_params_val); \
+    metac_value_t *p_res_val = metac_new_value_with_call_result(metac_entry_pointer_entry(p_entry)); \
     int res = metac_value_call(p_params_val, (void (*)(void)) p, p_res_val);
 
 

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -623,14 +623,20 @@ METAC_START_TEST(test_function_with_extra) {
 
 // variadic param tests
 int test_function_with_va_list(const char * format, va_list vl) {
+    // va_list l;
+    // va_copy(l, vl);
+    // int i = va_arg(l, int);
+    // va_end(l);
+    
     return vsnprintf(called, sizeof(called), format, vl);
+//    return 0;
 }
 METAC_GSYM_LINK(test_function_with_va_list);
 
 int test_function_with_va_args(const char * format, ...) {
     va_list l;
     va_start(l, format);
-    int res = test_function_with_va_list(format, l);
+    int res = vsnprintf(called, sizeof(called), format, l);
     va_end(l);
     return res;
 }
@@ -786,14 +792,16 @@ METAC_START_TEST(test_variadic_list) {
         {
     called[0] = 0;
     metac_entry_t * p_entry = METAC_GSYM_LINK_ENTRY(test_function_with_va_list);
-    metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(p_tagmap, p_entry, test_function_with_va_list, "test_function_with_va_list %d", VA_LIST(777));
+    metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(p_tagmap, p_entry,
+        test_function_with_va_list, "test_function_with_va_list %x %x %x %x %x %x", VA_LIST(1,2,3,4,5,6));
     metac_value_t *p_res_val = metac_new_value_with_call_result(p_entry);
     int res = metac_value_call(p_params_val, (void (*)(void)) test_function_with_va_list, p_res_val);
 
-            expected = "test_function_with_va_list(\"test_function_with_va_list %d\", VA_LIST((int)777))";
+            expected = "test_function_with_va_list(\"test_function_with_va_list %x %x %x %x %x %x\", "
+                "VA_LIST((unsigned int)1, (unsigned int)2, (unsigned int)3, (unsigned int)4, (unsigned int)5, (unsigned int)6))";
             s = metac_value_string_ex(p_params_val, METAC_WMODE_deep, p_tagmap);
             fail_unless(s != NULL);
-            //fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+            fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
             free(s);
 
             fail_unless(res == 0, "Call wasn't successful, expected successful");

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -14,7 +14,7 @@ static char called[1024];
     metac_entry_t * p_entry = METAC_GSYM_LINK_ENTRY(_fn_); \
     metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(_tag_map_, p_entry, _fn_, _args_); \
     metac_value_t *p_res_val = metac_new_value_with_call_result(p_entry); \
-    int res = metac_value_call(p_params_val, (void (*)(void)) _fn_, p_res_val);
+    int res = metac_value_ffi_call(p_params_val, (void (*)(void)) _fn_, p_res_val);
 
 #define _CALL_PROCESS_FN_PTR(_tag_map_, _type_, _fn_, _args_...) { \
     called[0] = 0; \
@@ -22,7 +22,7 @@ static char called[1024];
     metac_entry_t * p_entry = METAC_ENTRY_FROM_DECLLOC(dec, p); \
     metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(_tag_map_, metac_entry_pointer_entry(p_entry), _fn_, _args_); \
     metac_value_t *p_res_val = metac_new_value_with_call_result(metac_entry_pointer_entry(p_entry)); \
-    int res = metac_value_call(p_params_val, (void (*)(void)) p, p_res_val);
+    int res = metac_value_ffi_call(p_params_val, (void (*)(void)) p, p_res_val);
 
 
 #define _CALL_PROCESS_END \

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -623,13 +623,6 @@ METAC_START_TEST(test_function_with_extra) {
 
 // variadic param tests
 int test_function_with_va_list(const char * format, va_list vl) {
-    // void **p1 = &vl;
-    // fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
-    // va_list l;
-    // va_copy(l, vl);
-    // int i = va_arg(l, int);
-    // va_end(l);
-    
     return vsnprintf(called, sizeof(called), format, vl);
 }
 METAC_GSYM_LINK(test_function_with_va_list);
@@ -637,9 +630,7 @@ METAC_GSYM_LINK(test_function_with_va_list);
 int test_function_with_va_args(const char * format, ...) {
     va_list l;
     va_start(l, format);
-    // void **p1 = &l;
-    // fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
-    int res = test_function_with_va_list(format, l);//vsnprintf(called, sizeof(called), format, l);
+    int res = test_function_with_va_list(format, l);
     va_end(l);
     return res;
 }
@@ -774,32 +765,12 @@ METAC_START_TEST(test_variadic_arg) {
 
     _CALL_PROCESS_END
 
-
     metac_tag_map_delete(p_tagmap);
 }END_TEST
 
-// WARNING: this test doesn't work on x86 linux.. though works on big-endian linux
-// getting
-//value_ffi_test.c:804:F:default:test_variadic_list:0: called: got test_function_with_va_list 
-// 6c76 726d2f65 2d73762f 63617073 2f636174 2f656475, expected test_function_with_va_list 1 2 3 4 5 6
-// even though I'm getting debug dbg0: 1 2 3 4 5 6 before calling ffi_call
-// and even after. looks like I'm not clear on how to pass va_list... current implementation works
-// like it's a struct
-/*
-            values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
-            va_list cp;
-            va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
-            vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
-            va_end(cp);
-*/
-// that means that we can' pass va_list as argument, because we can't use it when we call fn.
-
-#if 0//__linux__
-START_TEST(test_variadic_list) {
-#else
 METAC_START_TEST(test_variadic_list) {
-#endif
     metac_tag_map_t * p_tagmap = va_args_tag_map();
+
 #define VA_LIST(_args_...) VA_LIST_FROM_CONTAINER(c, _args_)
 
     char * s = NULL;

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -775,10 +775,21 @@ METAC_START_TEST(test_variadic_arg) {
     metac_tag_map_delete(p_tagmap);
 }END_TEST
 
-// this test doesn't work on x86 linux.. though works on big-endian linux
+// WARNING: this test doesn't work on x86 linux.. though works on big-endian linux
 // getting
 //value_ffi_test.c:804:F:default:test_variadic_list:0: called: got test_function_with_va_list 
 // 6c76 726d2f65 2d73762f 63617073 2f636174 2f656475, expected test_function_with_va_list 1 2 3 4 5 6
+// even though I'm getting debug dbg0: 1 2 3 4 5 6 before calling ffi_call
+// and even after. looks like I'm not clear on how to pass va_list... current implementation works
+// like it's a struct
+/*
+            values[i] = &p_val_list_entries[va_list_number_cur].va_list_c.parameters;
+            va_list cp;
+            va_copy(cp, p_val_list_entries[va_list_number_cur].va_list_c.parameters);
+            vfprintf(stderr, "dbg0: %x %x %x %x %x %x\n", cp);
+            va_end(cp);
+*/
+// that means that we can' pass va_list as argument, because we can't use it when we call fn.
 
 #if __linux__
 START_TEST(test_variadic_list) {
@@ -815,7 +826,6 @@ METAC_START_TEST(test_variadic_list) {
             free(s);
 
         _CALL_PROCESS_END
-
     );
 
     metac_tag_map_delete(p_tagmap);

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -623,12 +623,12 @@ METAC_START_TEST(test_function_with_extra) {
 
 // variadic param tests
 int test_function_with_va_list(const char * format, va_list vl) {
-    void **p1 = &vl;
-    fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
-    va_list l;
-    va_copy(l, vl);
-    int i = va_arg(l, int);
-    va_end(l);
+    // void **p1 = &vl;
+    // fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
+    // va_list l;
+    // va_copy(l, vl);
+    // int i = va_arg(l, int);
+    // va_end(l);
     
     return vsnprintf(called, sizeof(called), format, vl);
 }
@@ -637,8 +637,8 @@ METAC_GSYM_LINK(test_function_with_va_list);
 int test_function_with_va_args(const char * format, ...) {
     va_list l;
     va_start(l, format);
-    void **p1 = &l;
-    fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
+    // void **p1 = &l;
+    // fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
     int res = test_function_with_va_list(format, l);//vsnprintf(called, sizeof(called), format, l);
     va_end(l);
     return res;

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -623,20 +623,23 @@ METAC_START_TEST(test_function_with_extra) {
 
 // variadic param tests
 int test_function_with_va_list(const char * format, va_list vl) {
-    // va_list l;
-    // va_copy(l, vl);
-    // int i = va_arg(l, int);
-    // va_end(l);
+    void **p1 = &vl;
+    fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
+    va_list l;
+    va_copy(l, vl);
+    int i = va_arg(l, int);
+    va_end(l);
     
     return vsnprintf(called, sizeof(called), format, vl);
-//    return 0;
 }
 METAC_GSYM_LINK(test_function_with_va_list);
 
 int test_function_with_va_args(const char * format, ...) {
     va_list l;
     va_start(l, format);
-    int res = vsnprintf(called, sizeof(called), format, l);
+    void **p1 = &l;
+    fprintf(stderr, "dbg:p1 %p: %p, %p p2\n", p1, *p1, *(p1+1));
+    int res = test_function_with_va_list(format, l);//vsnprintf(called, sizeof(called), format, l);
     va_end(l);
     return res;
 }
@@ -791,7 +794,7 @@ METAC_START_TEST(test_variadic_arg) {
 */
 // that means that we can' pass va_list as argument, because we can't use it when we call fn.
 
-#if __linux__
+#if 0//__linux__
 START_TEST(test_variadic_list) {
 #else
 METAC_START_TEST(test_variadic_list) {

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -806,10 +806,10 @@ METAC_START_TEST(test_variadic_list) {
 
             fail_unless(res == 0, "Call wasn't successful, expected successful");
 
-            expected_called = "test_function_with_va_list 777";
+            expected_called = "test_function_with_va_list 1 2 3 4 5 6";
             fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
 
-            expected = "30";
+            expected = "38";
             s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
             fail_unless(s != NULL);
             fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -4,6 +4,8 @@
 
 #include "value_ffi.c"
 
+#include "metac/backend/va_list_ex.h"
+
 // const arg count tests data
 static char called[1024];
 
@@ -500,7 +502,6 @@ METAC_START_TEST(test_function_with_array) {
     _CALL_PROCESS_END
 }END_TEST
 
-
 //unions hierarchy
 typedef union {
     union {
@@ -510,7 +511,6 @@ typedef union {
     union {
         long b_long;
         char b_char;
-        //char _padding_[15]; // to make it work
     } b;
 }test_union_hierarchy_t;
 
@@ -524,7 +524,6 @@ typedef struct {
         long b_long;
         char b_char;
     } b;
-    //char _padding_[15]; // to make it work
 }test_struct_with_union_t;
 
 // struct with bitfields
@@ -536,14 +535,12 @@ typedef struct {
     long lng11:7;
     long lng12:16;
     long lng13:30;
-    //char _padding_; //to make it work
 }test_struct_with_bitfields_t;
 
 // flexible arrays
 typedef struct {
     int len;
-    //char _padding_[7]; // to make it work
-    int arr[]; // 0,1,3,7 - don't work 2,4,5,6... 15 - works,, so basically 1,2,4,8 
+    int arr[]; 
 }test_struct_with_flexarr_t;
 
 test_struct_with_bitfields_t test_function_with_extra_cases(
@@ -570,7 +567,6 @@ test_struct_with_bitfields_t test_function_with_extra_cases(
         s_03 != NULL
     );
 
-    char s1 =
     snprintf(called, sizeof(called),
         "test_function_with_extra_cases %d %d %ld %s %s", 
         arg_00.a.a_int,
@@ -610,15 +606,12 @@ METAC_START_TEST(test_function_with_extra) {
 
         expected_called = "test_function_with_extra_cases 55 55 5555 "
             "(test_struct_with_bitfields_t []){{.lng01 = 1, .lng02 = 22222, .lng03 = 3, .lng11 = 11, .lng12 = 2222, .lng13 = 13,"
-            //" ._padding_ = 0,"
             "},} "
             "(test_struct_with_flexarr_t []){{.len = 1,"
-            //" ._padding_ = {0, 0, 0, 0, 0, 0, 0,},"
             " .arr = {},},}";
         fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
 
         expected = "{.lng01 = 1, .lng02 = 22222, .lng03 = 3, .lng11 = 11, .lng12 = 2222, .lng13 = 13,"
-            //" ._padding_ = 0,"
             "}";
         s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
         fail_unless(s != NULL);
@@ -626,4 +619,187 @@ METAC_START_TEST(test_function_with_extra) {
         free(s);
 
     _CALL_PROCESS_END
+}END_TEST
+
+// variadic param tests
+int test_function_with_va_list(const char * format, va_list vl) {
+    return vsnprintf(called, sizeof(called), format, vl);
+}
+METAC_GSYM_LINK(test_function_with_va_list);
+
+int test_function_with_va_args(const char * format, ...) {
+    va_list l;
+    va_start(l, format);
+    int res = test_function_with_va_list(format, l);
+    va_end(l);
+    return res;
+}
+METAC_GSYM_LINK(test_function_with_va_args);
+
+METAC_TAG_MAP_NEW(va_args_tag_map, NULL, {.mask = 
+            METAC_TAG_MAP_ENTRY_CATEGORY_MASK(METAC_TEC_variable) |
+            METAC_TAG_MAP_ENTRY_CATEGORY_MASK(METAC_TEC_func_parameter) | 
+            METAC_TAG_MAP_ENTRY_CATEGORY_MASK(METAC_TEC_member) |
+            METAC_TAG_MAP_ENTRY_CATEGORY_MASK(METAC_TEC_final),},)
+    /* start tags for all types */
+
+    METAC_TAG_MAP_ENTRY(METAC_GSYM_LINK_ENTRY(test_function_with_va_args))
+        METAC_TAG_MAP_SET_TAG(0, METAC_TEO_entry, 0, METAC_TAG_MAP_ENTRY_PARAMETER({.n = "format"}),
+            METAC_ZERO_ENDED_STRING()
+        )
+        METAC_TAG_MAP_SET_TAG(0, METAC_TEO_entry, 0, METAC_TAG_MAP_ENTRY_PARAMETER({.i = 1}), 
+            METAC_FORMAT_BASED_VA_ARG()
+        )
+    METAC_TAG_MAP_ENTRY_END
+
+    METAC_TAG_MAP_ENTRY(METAC_GSYM_LINK_ENTRY(test_function_with_va_list))
+        METAC_TAG_MAP_SET_TAG(0, METAC_TEO_entry, 0, METAC_TAG_MAP_ENTRY_PARAMETER({.n = "format"}),
+            METAC_ZERO_ENDED_STRING()
+        )
+        METAC_TAG_MAP_SET_TAG(0, METAC_TEO_entry, 0, METAC_TAG_MAP_ENTRY_PARAMETER({.n = "vl"}), 
+            METAC_FORMAT_BASED_VA_ARG()
+        )
+    METAC_TAG_MAP_ENTRY_END
+
+METAC_TAG_MAP_END
+
+METAC_START_TEST(test_variadic_arg) {
+    metac_tag_map_t * p_tagmap = va_args_tag_map();
+
+    char * s = NULL;
+    char * expected = NULL;
+    char * expected_called = NULL;
+
+    _CALL_PROCESS_FN(p_tagmap, test_function_with_va_args,
+        "test_function_with_va_args"
+    )
+        fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+        expected_called = "test_function_with_va_args";
+        fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+        expected = "26";
+        s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+        fail_unless(s != NULL);
+        fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+        free(s);
+    _CALL_PROCESS_END
+
+    _CALL_PROCESS_FN(p_tagmap, test_function_with_va_args,
+        "test_function_with_va_args %s", "ppp"
+    )
+        fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+        expected_called = "test_function_with_va_args ppp";
+        fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+        expected = "30";
+        s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+        fail_unless(s != NULL);
+        fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+        free(s);
+
+    _CALL_PROCESS_END
+
+    _CALL_PROCESS_FN(p_tagmap, test_function_with_va_args,
+        "test_function_with_va_args %d", 777
+    )
+        fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+        expected_called = "test_function_with_va_args 777";
+        fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+        expected = "30";
+        s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+        fail_unless(s != NULL);
+        fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+        free(s);
+
+    _CALL_PROCESS_END
+
+    _CALL_PROCESS_FN(p_tagmap, test_function_with_va_args,
+        "test_function_with_va_args %o, %u, %x, %X", 1180000, 1200000, 1210000, 1220000
+    )
+        fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+        expected_called = "test_function_with_va_args 4400540, 1200000, 127690, 129DA0";
+        fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+        expected = "59";
+        s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+        fail_unless(s != NULL);
+        fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+        free(s);
+
+    _CALL_PROCESS_END
+
+    _CALL_PROCESS_FN(p_tagmap, test_function_with_va_args,
+        "test_function_with_va_args %lo, %lu, %lx, %lX", 11800000L, 12000000L, 12100000L, 12200000L
+    )
+        fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+        expected_called = "test_function_with_va_args 55006700, 12000000, b8a1a0, BA2840";
+        fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+        expected = "61";
+        s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+        fail_unless(s != NULL);
+        fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+        free(s);
+
+    _CALL_PROCESS_END
+
+    _CALL_PROCESS_FN(p_tagmap, test_function_with_va_args,
+        "test_function_with_va_args %f, %g, %e", 11.1, 11.2, -11.3
+    )
+        fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+        expected_called = "test_function_with_va_args 11.100000, 11.2, -1.130000e+01";
+        fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+        expected = "57";
+        s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+        fail_unless(s != NULL);
+        fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+        free(s);
+
+    _CALL_PROCESS_END
+
+
+    metac_tag_map_delete(p_tagmap);
+}END_TEST
+
+METAC_START_TEST(test_variadic_list) {
+    metac_tag_map_t * p_tagmap = va_args_tag_map();
+#define VA_LIST(_args_...) VA_LIST_FROM_CONTAINER(c, _args_)
+
+    char * s = NULL;
+    char * expected = NULL;
+    char * expected_called = NULL;
+
+    WITH_VA_LIST_CONTAINER(c, 
+        _CALL_PROCESS_FN(p_tagmap, test_function_with_va_list,
+            "test_function_with_va_list %d", VA_LIST(777)
+        )
+            expected = "test_function_with_va_list(\"test_function_with_va_list %d\", VA_LIST((int)777))";
+            s = metac_value_string_ex(p_params_val, METAC_WMODE_deep, p_tagmap);
+            fail_unless(s != NULL);
+            //fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+            free(s);
+
+            fail_unless(res == 0, "Call wasn't successful, expected successful");
+
+            expected_called = "test_function_with_va_list 777";
+            fail_unless(strcmp(called, expected_called) == 0, "called: got %s, expected %s", called, expected_called);
+
+            expected = "30";
+            s = metac_value_string_ex(p_res_val, METAC_WMODE_deep, NULL);
+            fail_unless(s != NULL);
+            fail_unless(strcmp(s, expected) == 0, "got %s, expected %s", s, expected);
+            free(s);
+
+        _CALL_PROCESS_END
+    );
+
+    metac_tag_map_delete(p_tagmap);
 }END_TEST

--- a/examples/c_ffi_call/value_ffi_test.c
+++ b/examples/c_ffi_call/value_ffi_test.c
@@ -777,10 +777,19 @@ METAC_START_TEST(test_variadic_list) {
     char * expected = NULL;
     char * expected_called = NULL;
 
-    WITH_VA_LIST_CONTAINER(c, 
-        _CALL_PROCESS_FN(p_tagmap, test_function_with_va_list,
-            "test_function_with_va_list %d", VA_LIST(777)
-        )
+    do {
+        struct va_list_container c;
+        void * _ptr_ = NULL;
+        // _CALL_PROCESS_FN(p_tagmap, test_function_with_va_list,
+        //     "test_function_with_va_list %d", VA_LIST(777)
+        // )
+        {
+    called[0] = 0;
+    metac_entry_t * p_entry = METAC_GSYM_LINK_ENTRY(test_function_with_va_list);
+    metac_value_t * p_params_val = METAC_NEW_VALUE_WITH_CALL_PARAMS_AND_WRAP(p_tagmap, p_entry, test_function_with_va_list, "test_function_with_va_list %d", VA_LIST(777));
+    metac_value_t *p_res_val = metac_new_value_with_call_result(p_entry);
+    int res = metac_value_call(p_params_val, (void (*)(void)) test_function_with_va_list, p_res_val);
+
             expected = "test_function_with_va_list(\"test_function_with_va_list %d\", VA_LIST((int)777))";
             s = metac_value_string_ex(p_params_val, METAC_WMODE_deep, p_tagmap);
             fail_unless(s != NULL);
@@ -799,7 +808,9 @@ METAC_START_TEST(test_variadic_list) {
             free(s);
 
         _CALL_PROCESS_END
-    );
+
+        va_end(c.parameters);
+    }while(0);
 
     metac_tag_map_delete(p_tagmap);
 }END_TEST

--- a/include/metac/reflect/value.h
+++ b/include/metac/reflect/value.h
@@ -397,4 +397,15 @@ metac_value_t * metac_value_parameter_wrap(metac_value_t * p_val,metac_tag_map_t
    tag_map is needed in case the function in p_entry has unspecified parameter or va_list */
 metac_value_t * metac_value_parameter_vwrap(metac_value_t * p_val,metac_tag_map_t * p_tag_map, va_list parameters);
 
+/** @brief function to create parameter_storage and wrap it into subprogram/subroutine entry */
+metac_value_t * metac_new_value_with_call_params(metac_entry_t *p_entry);
+/** @brief cleanup value created by metac_new_value_with_call_params (including parameter_storage) */
+void metac_value_with_call_params_delete(metac_value_t * p_param_value);
+
+/** @brief function to reserve memory for the result subprogram/subroutine and wrap it into subprogram/subroutine entry 
+ * return NULL if function/subroutine doesn't have result */
+metac_value_t * metac_new_value_with_call_result(metac_entry_t * p_entry);
+/** @brief cleanup value created by metac_new_value_with_call_result (including place). handles NULL argument correctly */
+void metac_value_with_call_result_delete(metac_value_t * p_res_value);
+
 #endif

--- a/src/value.c
+++ b/src/value.c
@@ -795,3 +795,58 @@ void metac_value_delete(metac_value_t * p_val) {
     // clean our mem
     free(p_val);
 }
+
+// extended functions
+metac_value_t * metac_new_value_with_call_params(metac_entry_t *p_entry) {
+    metac_value_t * p_val = NULL;
+    metac_parameter_storage_t * p_param_storage = metac_new_parameter_storage();
+    if (p_param_storage != NULL) {
+        p_val = metac_new_value(p_entry, p_param_storage);
+    }
+    return p_val;
+}
+
+void metac_value_with_call_params_delete(metac_value_t * p_param_value) {
+    metac_parameter_storage_t * p_param_storage = (metac_parameter_storage_t *)metac_value_addr(p_param_value);
+    metac_value_delete(p_param_value);
+    metac_parameter_storage_delete(p_param_storage);
+}
+
+metac_value_t * metac_new_value_with_call_result(metac_entry_t * p_entry) {
+    _check_(
+        p_entry == NULL ||
+        metac_entry_has_parameter_load(p_entry) == 0, NULL);
+
+    metac_value_t * p_res_value = NULL;
+    metac_size_t res_sz = 0;
+
+    _check_(metac_entry_has_parameters(p_entry) == 0, NULL);
+
+    if (metac_entry_has_result(p_entry) != 0) {
+        metac_entry_t *p_res_entry = metac_entry_result_type(p_entry);
+        _check_(p_res_entry == NULL, NULL);
+
+        if (metac_entry_byte_size(p_res_entry, &res_sz) != 0) {
+            return NULL;
+        }
+        _check_(res_sz <= 0, NULL);
+
+        void * p_res_mem = calloc(1, res_sz);
+        p_res_value = metac_new_value(p_res_entry, p_res_mem);
+        if (p_res_value == NULL) {
+            free(p_res_mem);
+            return NULL;
+        }
+    }
+
+    return p_res_value;
+}
+
+void metac_value_with_call_result_delete(metac_value_t * p_res_value) {
+    if (p_res_value == NULL) {
+        return;
+    }
+    free(metac_value_addr(p_res_value));
+    metac_value_delete(p_res_value);
+}
+


### PR DESCRIPTION
- includes support of vairadic variables, va_list and their tests
- moved generic part of api into the libmetac. left in example only call function which is based on libffi